### PR TITLE
small gas optimizations in BTCDepositAddressDeriver and Bech32m libraries

### DIFF
--- a/src/BTCDepositAddressDeriver.sol
+++ b/src/BTCDepositAddressDeriver.sol
@@ -32,8 +32,8 @@ contract BTCDepositAddressDeriver {
     }
 
     function parseBTCTaprootAddress(
-        string memory hrp,
-        string memory addr
+        string calldata hrp,
+        string calldata addr
     ) public pure returns (uint256, uint256) {
         (uint8 witVer, bytes memory witProg, Bech32m.DecodeError err) = Bech32m
             .decodeSegwitAddress(bytes(hrp), bytes(addr));
@@ -54,9 +54,9 @@ contract BTCDepositAddressDeriver {
     }
 
     function setSeed(
-        string memory _btcAddr1,
-        string memory _btcAddr2,
-        string memory _hrp
+        string calldata _btcAddr1,
+        string calldata _btcAddr2,
+        string calldata _hrp
     ) public {
         networkHrp = _hrp;
         (p1x, p1y) = parseBTCTaprootAddress(_hrp, _btcAddr1);

--- a/src/Bech32m.sol
+++ b/src/Bech32m.sol
@@ -676,8 +676,8 @@ library Bech32m {
     // return (data[0], decoded)
     // returns witVer, witProg, err
     function decodeSegwitAddress(
-        bytes memory expectedHrp,
-        bytes memory addr
+        bytes calldata expectedHrp,
+        bytes calldata addr
     ) public pure returns (uint8, bytes memory, DecodeError) {
         (
             bytes memory hrpGot,

--- a/src/Bech32m.sol
+++ b/src/Bech32m.sol
@@ -268,7 +268,7 @@ library Bech32m {
         // <hrp> 1 <data-5bit-format> <6bytes of chk-5bit-format>
 
         // 1 byte for the separator
-        bytes1 SEPARATOR = bytes1(0x31);
+        bytes1 constant SEPARATOR = bytes1(0x31);
 
         // reuse data and chk arrays to modify data in place to save gas
 


### PR DESCRIPTION
Test gas savings with:
```bash
forge snapshot 
# change code
forge snapshot --diff
```

And 
```bash
forge test --gas-report
```

Results:

```
Ran 3 test suites in 144.08ms (60.30ms CPU time): 29 tests passed, 0 failed, 0 skipped (29 total tests)
testAreBytesEqual() (gas: 0 (0.000%))
testBech32mConstant() (gas: 0 (0.000%))
testCharset() (gas: 0 (0.000%))
testIsMixedCase() (gas: 0 (0.000%))
testIsValidCharacterRange() (gas: 0 (0.000%))
testPolymod() (gas: 0 (0.000%))
testCoefficientDerivation() (gas: 0 (0.000%))
testDerivationPubkey() (gas: 0 (0.000%))
testPubkeyFromAddree() (gas: 0 (0.000%))
testHrpExpand() (gas: 6 (0.008%))
testInvalidAddress() (gas: 1020 (0.019%))
testBech32DecodeSpecBech32m() (gas: 296 (0.026%))
testBech32DecodeSpecBech32() (gas: 296 (0.026%))
testBech32Decode() (gas: 144 (0.062%))
testCreateChecksum() (gas: 66 (0.081%))
testDecodeCharactersBech32() (gas: 178 (0.148%))
testSetSeed() (gas: -1916 (-0.214%))
testConvert8To5() (gas: 364 (0.222%))
testParseBTCTaprootAddress2() (gas: -716 (-0.238%))
testParseBTCTaprootAddress1() (gas: -716 (-0.238%))
testToLower() (gas: 100 (0.267%))
testConvert5To8() (gas: 3046 (0.332%))
testBech32DecodeSpecInvalidBech32m() (gas: 952 (0.361%))
testBech32DecodeSpecInvalidBech32() (gas: 816 (0.404%))
testGetBTCDepositAddress() (gas: -28654 (-1.217%))
testGetBtcAddressFromEth() (gas: -26908 (-1.784%))
testBech32Encode() (gas: -6471 (-5.414%))
testValidAddressDecodeEncode() (gas: -174551 (-6.466%))
testEncodeSegwitAddress() (gas: -97746 (-17.971%))
Overall gas change: -330394 (-1.544%)
```