### PR TITLE
the old and new functionality for generating BTC addresses was separated

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -12,7 +12,7 @@ import {AddressReaderWriter} from "./AddressReaderWriter.s.sol";
 contract Deploy is Script, AddressReaderWriter {
     function run() external returns (BTCDepositAddressDeriver) {
         vm.startBroadcast();
-        BTCDepositAddressDeriver btcDepositAddressDeriver = new BTCDepositAddressDeriver();
+        BTCDepositAddressDeriver btcDepositAddressDeriver = new BTCDepositAddressDeriver(msg.sender);
         vm.stopBroadcast();
         writeContractAddress("BTCDepositAddressDeriver", address(btcDepositAddressDeriver));
         return btcDepositAddressDeriver;

--- a/src/BTCDepositAddressDeriver.sol
+++ b/src/BTCDepositAddressDeriver.sol
@@ -2,22 +2,18 @@
 
 pragma solidity 0.8.27;
 
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Deriver} from "./Deriver.sol";
 import {Bech32m} from "./Bech32m.sol";
 import {BitcoinNetworkEncoder} from "./BitcoinNetworkEncoder.sol";
 
 error SeedWasNotSetYet();
 error UnsupportedBtcAddress(string btcAddress);
-error CannotParseBtcAddress(
-    string btcAddress,
-    string hrp,
-    Bech32m.DecodeError err
-);
+error CannotParseBtcAddress(string btcAddress, string hrp, Bech32m.DecodeError err);
 
 // Types of Bitcoin Network
 
-contract BTCDepositAddressDeriver {
-
+contract BTCDepositAddressDeriver is Ownable {
     event SeedChanged(string btcAddr, string hrp);
 
     bool public wasSeedSet;
@@ -32,15 +28,12 @@ contract BTCDepositAddressDeriver {
     uint256 public p1x;
     uint256 public p1y;
 
-    constructor() {
+    constructor(address initialOwner) Ownable(initialOwner) {
         wasSeedSet = false;
     }
 
     // Set Validators' joint pubkey and network prefix, must be called after contract deployment
-    function setSeed(
-        string calldata _btcAddr,
-        BitcoinNetworkEncoder.Network _network
-    ) public virtual {
+    function setSeed(string calldata _btcAddr, BitcoinNetworkEncoder.Network _network) public virtual onlyOwner {
         string memory _hrp = BitcoinNetworkEncoder.getNetworkPrefix(_network);
 
         networkHrp = _hrp;
@@ -54,13 +47,13 @@ contract BTCDepositAddressDeriver {
     }
 
     // Derive pubkey's (x,y) coordinates from taproot address
-    function parseBTCTaprootAddress(
-        string memory _hrp,
-        string calldata _bitcoinAddress
-    ) public pure returns (uint256, uint256) {
-
-        (uint8 witVer, bytes memory witProg, Bech32m.DecodeError err) = Bech32m
-            .decodeSegwitAddress(bytes(_hrp), bytes(_bitcoinAddress));
+    function parseBTCTaprootAddress(string memory _hrp, string calldata _bitcoinAddress)
+        public
+        pure
+        returns (uint256, uint256)
+    {
+        (uint8 witVer, bytes memory witProg, Bech32m.DecodeError err) =
+            Bech32m.decodeSegwitAddress(bytes(_hrp), bytes(_bitcoinAddress));
 
         if (err != Bech32m.DecodeError.NoError) {
             revert CannotParseBtcAddress(_bitcoinAddress, _hrp, err);
@@ -81,20 +74,11 @@ contract BTCDepositAddressDeriver {
     }
 
     // Get users' Bitcoin deposit address from user's Stroom NFT token ID
-    function getBTCDepositAddress(
-        uint256 index
-    ) public virtual view returns (string memory) {
-
+    function getBTCDepositAddress(uint256 index) public view virtual returns (string memory) {
         if (!wasSeedSet) {
             revert SeedWasNotSetYet();
         }
 
-        return
-            Deriver.deriveReceivingAddressFromIndex(
-                p1x,
-                p1y,
-                index,
-                bytes(networkHrp)
-            );
+        return Deriver.deriveReceivingAddressFromIndex(p1x, p1y, index, bytes(networkHrp));
     }
 }

--- a/src/Deriver.sol
+++ b/src/Deriver.sol
@@ -3,7 +3,6 @@
 pragma solidity 0.8.27;
 
 import {EllipticCurve} from "../lib/elliptic-curve-solidity/contracts/EllipticCurve.sol";
-
 import {Hmac} from "./Hmac.sol";
 import {Bech32m} from "./Bech32m.sol";
 
@@ -30,19 +29,6 @@ library Deriver {
     // sha256("TapTweak")
     bytes32 public constant SHA256_TAP_TWEAK =
         hex"e80fe1639c9ca050e3af1b39c143c63e429cbceb15d940fbb5c5a1f4af57c5e9";
-    
-    // Note: Tagged hashes are not needed here as this function:
-    // 1. Has clearly typed inputs
-    // 2. Is used only for internal coefficient derivation
-    // 3. Does not interact directly with Bitcoin protocol
-    function getCoefficient(
-        uint256 x1,
-        uint256 y1,
-        address a
-    ) internal pure returns (uint256) {
-        uint256 c = uint256(sha256(abi.encode(x1, y1, a)));
-        return c;
-    }
 
     // pubkey add operation
     function addPubkeys(
@@ -61,42 +47,6 @@ library Deriver {
         uint256 scalar
     ) internal pure returns (uint256, uint256) {
         return EllipticCurve.ecMul(scalar, x, y, AA, PP);
-    }
-
-    // linear combination of two pubkeys
-    // Note: resulting point may have odd y coordinate(not compatible with BIP-340), however
-    // if it is used for address derivation which requires only x coordinate, it is not a problem.
-    // But if you use this pubkey for other purposes, you should check y coordinate and negate the point if necessary.
-    function getCombinedPubkey(
-        uint256 p1x,
-        uint256 p1y,
-        uint256 p2x,
-        uint256 p2y,
-        uint256 c1,
-        uint256 c2
-    ) internal pure returns (uint256, uint256) {
-        (uint256 x1, uint256 y1) = mulPubkey(p1x, p1y, c1);
-        (uint256 x2, uint256 y2) = mulPubkey(p2x, p2y, c2);
-
-        (uint256 x3, uint256 y3) = addPubkeys(x1, y1, x2, y2);
-       
-        // Note: y-coordinate parity check is handled in getBtcAddressTaprootNoScriptFromEth
-        // where it's actually needed for BIP-340 compatibility
-        
-        return (x3, y3);
-    }
-
-    // derive pubkey from Validators' pubkeys and user's Ethereum address
-    function getPubkeyFromAddress(
-        uint256 p1x,
-        uint256 p1y,
-        uint256 p2x,
-        uint256 p2y,
-        address addr
-    ) internal pure returns (uint256, uint256) {
-        uint256 c1 = getCoefficient(p1x, p1y, addr);
-        uint256 c2 = getCoefficient(p2x, p2y, addr);
-        return getCombinedPubkey(p1x, p1y, p2x, p2y, c1, c2);
     }
 
     // derive Bitcoin address from pubkey
@@ -134,34 +84,6 @@ library Deriver {
         return (x2, y2);
     }
 
-    // derive Bitcoin address from user's Ethereum address and validators' pubkeys
-    // It generate taproot address with taproot commitment and no script path(preferred way according to BIP-341)
-    function getBtcAddressTaprootNoScriptFromEth(
-        uint256 p1x,
-        uint256 p1y,
-        uint256 p2x,
-        uint256 p2y,
-        bytes memory hrp,
-        address ethAddr
-    ) internal pure returns (string memory) {
-        (uint256 x, uint256 y) = getPubkeyFromAddress(
-            p1x,
-            p1y,
-            p2x,
-            p2y,
-            ethAddr
-        );
-
-        // BIP-340 requires even y-coordinate for public keys
-        if (y % 2 == 1) {
-            y = PP - y;
-        }
-
-        (uint256 xTweaked,) = computeTaprootKeyNoScript(x, y);
-
-        return getBtcTaprootAddrFromPubkey(xTweaked, hrp);
-    }
-
     // Public key derivation works only for normal(not hardened) child keys.
     // index < HARDENED_KEY_START
     function deriveChildPubkeyBip32(
@@ -183,7 +105,7 @@ library Deriver {
             uint32(index)
         );
 
-        (bytes32 ilBytes32, bytes32 irBytes32) = Hmac.hmacSha512(abi.encodePacked(chainCode), data);
+        (bytes32 ilBytes32,) = Hmac.hmacSha512(abi.encodePacked(chainCode), data);
         uint256 il = uint256(ilBytes32);
 
         require(il < NN, "il must be less than NN");

--- a/src/LegacyBTCDepositAddressDeriver.sol
+++ b/src/LegacyBTCDepositAddressDeriver.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.27;
+
+import {LegacyDeriver} from "./LegacyDeriver.sol";
+import {Bech32m} from "./Bech32m.sol";
+import {BitcoinNetworkEncoder} from "./BitcoinNetworkEncoder.sol";
+
+error SeedWasNotSetYet();
+error UnsupportedBtcAddress(string btcAddress);
+error CannotParseBtcAddress(
+    string btcAddress,
+    string hrp,
+    Bech32m.DecodeError err
+);
+
+// Types of Bitcoin Network
+
+contract LegacyBTCDepositAddressDeriver {
+
+    event SeedChanged(string btcAddr1, string btcAddr2, string hrp);
+
+    bool public wasSeedSet;
+
+    // Validators' joint pubkeys in format of taproot addresses
+    string public btcAddr1;
+    string public btcAddr2;
+
+    // Bitcoin address's network prefix
+    string public networkHrp;
+
+    // Validators' pubkey both coordinates deconstructed from taproot addresses
+    uint256 public p1x;
+    uint256 public p1y;
+    uint256 public p2x;
+    uint256 public p2y;
+
+    constructor() {
+        wasSeedSet = false;
+    }
+
+    // Set Validators' joint pubkeys and network prefix, must be called after contract deployment
+    function setSeed(
+        string calldata _btcAddr1,
+        string calldata _btcAddr2,
+        BitcoinNetworkEncoder.Network _network
+    ) public virtual {
+        string memory _hrp = BitcoinNetworkEncoder.getNetworkPrefix(_network);
+
+        networkHrp = _hrp;
+
+        (p1x, p1y) = parseBTCTaprootAddress(_hrp, _btcAddr1);
+        (p2x, p2y) = parseBTCTaprootAddress(_hrp, _btcAddr2);
+
+        btcAddr1 = _btcAddr1;
+        btcAddr2 = _btcAddr2;
+
+        wasSeedSet = true;
+        emit SeedChanged(_btcAddr1, _btcAddr2, _hrp);
+    }
+
+    // Derive pubkey's (x,y) coordinates from taproot address
+    function parseBTCTaprootAddress(
+        string memory _hrp,
+        string calldata _bitcoinAddress
+    ) public pure returns (uint256, uint256) {
+
+        (uint8 witVer, bytes memory witProg, Bech32m.DecodeError err) = Bech32m
+            .decodeSegwitAddress(bytes(_hrp), bytes(_bitcoinAddress));
+
+        if (err != Bech32m.DecodeError.NoError) {
+            revert CannotParseBtcAddress(_bitcoinAddress, _hrp, err);
+        }
+        if (witVer != 1 || witProg.length != 32) {
+            revert UnsupportedBtcAddress(_bitcoinAddress);
+        }
+
+        uint256 x = uint256(bytes32(witProg));
+
+        if (x == 0 || x >= LegacyDeriver.PP) {
+            revert UnsupportedBtcAddress(_bitcoinAddress);
+        }
+
+        uint256 y = LegacyDeriver.liftX(x);
+
+        return (x, y);
+    }
+
+    // Get users' Bitcoin deposit address from user's Ethereum address
+    function getBTCDepositAddress(
+        address ethAddr
+    ) public virtual view returns (string memory) {
+
+        if (!wasSeedSet) {
+            revert SeedWasNotSetYet();
+        }
+
+        return
+            LegacyDeriver.getBtcAddressTaprootNoScriptFromEth(
+                p1x,
+                p1y,
+                p2x,
+                p2y,
+                bytes(networkHrp),
+                ethAddr
+            );
+    }
+}

--- a/src/LegacyDeriver.sol
+++ b/src/LegacyDeriver.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.27;
+
+import {EllipticCurve} from "../lib/elliptic-curve-solidity/contracts/EllipticCurve.sol";
+
+import {Bech32m} from "./Bech32m.sol";
+
+library LegacyDeriver {
+    // BEGIN SECP256k1 CONSTANTS
+    uint256 public constant GX =
+        0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798;
+    uint256 public constant GY =
+        0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8;
+    uint256 public constant AA = 0;
+    uint256 public constant BB = 7;
+    uint256 public constant PP =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F;
+    // END SECP256k1 CONSTANTS
+
+    // sha256("TapTweak")
+    bytes32 public constant SHA256_TAP_TWEAK =
+        hex"e80fe1639c9ca050e3af1b39c143c63e429cbceb15d940fbb5c5a1f4af57c5e9";
+    
+    // Note: Tagged hashes are not needed here as this function:
+    // 1. Has clearly typed inputs
+    // 2. Is used only for internal coefficient derivation
+    // 3. Does not interact directly with Bitcoin protocol
+    function getCoefficient(
+        uint256 x1,
+        uint256 y1,
+        address a
+    ) internal pure returns (uint256) {
+        uint256 c = uint256(sha256(abi.encode(x1, y1, a)));
+        return c;
+    }
+
+    // pubkey add operation
+    function addPubkeys(
+        uint256 x1,
+        uint256 y1,
+        uint256 x2,
+        uint256 y2
+    ) internal pure returns (uint256, uint256) {
+        return EllipticCurve.ecAdd(x1, y1, x2, y2, AA, PP);
+    }
+
+    // pubkey multiplication by scalar operation
+    function mulPubkey(
+        uint256 x,
+        uint256 y,
+        uint256 scalar
+    ) internal pure returns (uint256, uint256) {
+        return EllipticCurve.ecMul(scalar, x, y, AA, PP);
+    }
+
+    // linear combination of two pubkeys
+    // Note: resulting point may have odd y coordinate(not compatible with BIP-340), however
+    // if it is used for address derivation which requires only x coordinate, it is not a problem.
+    // But if you use this pubkey for other purposes, you should check y coordinate and negate the point if necessary.
+    function getCombinedPubkey(
+        uint256 p1x,
+        uint256 p1y,
+        uint256 p2x,
+        uint256 p2y,
+        uint256 c1,
+        uint256 c2
+    ) internal pure returns (uint256, uint256) {
+        (uint256 x1, uint256 y1) = mulPubkey(p1x, p1y, c1);
+        (uint256 x2, uint256 y2) = mulPubkey(p2x, p2y, c2);
+
+        (uint256 x3, uint256 y3) = addPubkeys(x1, y1, x2, y2);
+       
+        // Note: y-coordinate parity check is handled in getBtcAddressTaprootNoScriptFromEth
+        // where it's actually needed for BIP-340 compatibility
+        
+        return (x3, y3);
+    }
+
+    // derive pubkey from Validators' pubkeys and user's Ethereum address
+    function getPubkeyFromAddress(
+        uint256 p1x,
+        uint256 p1y,
+        uint256 p2x,
+        uint256 p2y,
+        address addr
+    ) internal pure returns (uint256, uint256) {
+        uint256 c1 = getCoefficient(p1x, p1y, addr);
+        uint256 c2 = getCoefficient(p2x, p2y, addr);
+        return getCombinedPubkey(p1x, p1y, p2x, p2y, c1, c2);
+    }
+
+    // derive Bitcoin address from pubkey
+    // only x coordinate is used for address generation
+    function getBtcTaprootAddrFromPubkey(
+        uint256 x,
+        bytes memory hrp
+    ) internal pure returns (string memory) {
+        return string(Bech32m.encodeSegwitAddress(hrp, 1, abi.encodePacked(x)));
+    }
+
+    // calculate y coordinate from x coordinate
+    function liftX(uint256 x) internal pure returns (uint256) {
+        return EllipticCurve.deriveY(0x02, x, AA, BB, PP);
+    }
+
+    // tweaks pubkey with a no script path
+    // According to BIP 341: "If the spending conditions do not require a script path,
+    // the output key should commit to an unspendable script path instead of having no script path"
+    // Note: resulting point may have odd y coordinate(not compatible with BIP-340), however
+    // it is used for address derivation which requires only x coordinate.
+    function computeTaprootKeyNoScript(
+        uint256 x,
+        uint256 y
+    ) internal pure returns (uint256, uint256) {
+        // Calculate TaggedHash("TapTweak", x)
+        uint256 h = uint256(
+            sha256(abi.encode(SHA256_TAP_TWEAK, SHA256_TAP_TWEAK, x))
+        );
+
+        (uint256 x1, uint256 y1) = mulPubkey(GX, GY, h);
+
+        (uint256 x2, uint256 y2) = addPubkeys(x, y, x1, y1);
+
+        return (x2, y2);
+    }
+
+    // derive Bitcoin address from user's Ethereum address and validators' pubkeys
+    // It generate taproot address with taproot commitment and no script path(preferred way according to BIP-341)
+    // Better to use this function instead of getBtcAddressFromEth
+    function getBtcAddressTaprootNoScriptFromEth(
+        uint256 p1x,
+        uint256 p1y,
+        uint256 p2x,
+        uint256 p2y,
+        bytes memory hrp,
+        address ethAddr
+    ) internal pure returns (string memory) {
+        (uint256 x, uint256 y) = getPubkeyFromAddress(
+            p1x,
+            p1y,
+            p2x,
+            p2y,
+            ethAddr
+        );
+
+        // BIP-340 requires even y-coordinate for public keys
+        if (y % 2 == 1) {
+            y = PP - y;
+        }
+
+        (uint256 xTweaked,) = computeTaprootKeyNoScript(x, y);
+
+        return getBtcTaprootAddrFromPubkey(xTweaked, hrp);
+    }
+}

--- a/test/BTCDepositAddressDeriver.t.sol
+++ b/test/BTCDepositAddressDeriver.t.sol
@@ -11,178 +11,104 @@ contract BTCDepositAddressDeriverTest is Test {
     BTCDepositAddressDeriver deriver;
 
     function setUp() public {
-        deriver = new BTCDepositAddressDeriver();
+        deriver = new BTCDepositAddressDeriver(address(this));
     }
 
-    function testParseBTCTaprootAddress1() public view{
-        (uint256 x, uint256 y) = deriver.parseBTCTaprootAddress(
-            "tb",
-            "tb1p7g532zgvuzv8fz3hs02wvn2almqh8qyvz4xdr564nannkxh28kdq62ewy3"
-        );
-        assertEq(
-            x,
-            0xF22915090CE098748A3783D4E64D5DFEC173808C154CD1D3559F673B1AEA3D9A
-        );
-        assertEq(
-            y,
-            0xEE340CB6B7C08A2B96B7C34A70B5B980FAD90AD4E9D0BE50302DA7542A73C0E0
-        );
+    function testParseBTCTaprootAddress1() public view {
+        (uint256 x, uint256 y) =
+            deriver.parseBTCTaprootAddress("tb", "tb1p7g532zgvuzv8fz3hs02wvn2almqh8qyvz4xdr564nannkxh28kdq62ewy3");
+        assertEq(x, 0xF22915090CE098748A3783D4E64D5DFEC173808C154CD1D3559F673B1AEA3D9A);
+        assertEq(y, 0xEE340CB6B7C08A2B96B7C34A70B5B980FAD90AD4E9D0BE50302DA7542A73C0E0);
     }
 
     function testParseBTCTaprootAddress2() public view {
-        (uint256 x, uint256 y) = deriver.parseBTCTaprootAddress(
-            "tb",
-            "tb1psfpmk6v8cvd8kr4rdda0l8gwyn42v5yfjlqkhnureprgs5tuumkqvdkewz"
-        );
-        assertEq(
-            x,
-            0x8243BB6987C31A7B0EA36B7AFF9D0E24EAA6508997C16BCF83C84688517CE6EC
-        );
-        assertEq(
-            y,
-            0x4FEF9EF44EA93A90E91CB9ED229F0D684F6A56EBB0787174369D4DADDCB1A85C
-        );
+        (uint256 x, uint256 y) =
+            deriver.parseBTCTaprootAddress("tb", "tb1psfpmk6v8cvd8kr4rdda0l8gwyn42v5yfjlqkhnureprgs5tuumkqvdkewz");
+        assertEq(x, 0x8243BB6987C31A7B0EA36B7AFF9D0E24EAA6508997C16BCF83C84688517CE6EC);
+        assertEq(y, 0x4FEF9EF44EA93A90E91CB9ED229F0D684F6A56EBB0787174369D4DADDCB1A85C);
     }
 
     function testParseBTCTaprootAddress3() public {
         vm.expectRevert();
-        deriver.parseBTCTaprootAddress(
-            "tb",
-            "tc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq5zuyut"
-        );
+        deriver.parseBTCTaprootAddress("tb", "tc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq5zuyut");
     }
 
     function testParseBTCTaprootAddress4() public {
         vm.expectRevert();
-        deriver.parseBTCTaprootAddress(
-            "bc",
-            "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqh2y7hd"
-        );
+        deriver.parseBTCTaprootAddress("bc", "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqh2y7hd");
     }
 
     function testParseBTCTaprootAddress5() public {
         vm.expectRevert();
-        deriver.parseBTCTaprootAddress(
-            "bc",
-            "BC1S0XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ54WELL"
-        );
+        deriver.parseBTCTaprootAddress("bc", "BC1S0XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ54WELL");
     }
 
     function testParseBTCTaprootAddress6() public {
         vm.expectRevert();
-        deriver.parseBTCTaprootAddress(
-            "tb",
-            "tb1q0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq24jc47"
-        );
+        deriver.parseBTCTaprootAddress("tb", "tb1q0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq24jc47");
     }
 
     function testParseBTCTaprootAddress7() public {
         vm.expectRevert();
-        deriver.parseBTCTaprootAddress(
-            "bc",
-            "bc1p38j9r5y49hruaue7wxjce0updqjuyyx0kh56v8s25huc6995vvpql3jow4"
-        );
+        deriver.parseBTCTaprootAddress("bc", "bc1p38j9r5y49hruaue7wxjce0updqjuyyx0kh56v8s25huc6995vvpql3jow4");
     }
 
     function testParseBTCTaprootAddress8() public {
         vm.expectRevert();
-        deriver.parseBTCTaprootAddress(
-            "bc",
-            "BC130XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ7ZWS8R"
-        );
+        deriver.parseBTCTaprootAddress("bc", "BC130XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ7ZWS8R");
     }
 
     function testParseBTCTaprootAddress9() public {
         vm.expectRevert();
-        deriver.parseBTCTaprootAddress(
-            "bc",
-            "bc1pw5dgrnzv"
-        );
+        deriver.parseBTCTaprootAddress("bc", "bc1pw5dgrnzv");
     }
 
     function testParseBTCTaprootAddress10() public {
         vm.expectRevert();
         deriver.parseBTCTaprootAddress(
-            "bc",
-            "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v8n0nx0muaewav253zgeav"
+            "bc", "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v8n0nx0muaewav253zgeav"
         );
     }
 
     function testParseBTCTaprootAddress11() public {
         vm.expectRevert();
-        deriver.parseBTCTaprootAddress(
-            "tb",
-            "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47Zagq"
-        );
+        deriver.parseBTCTaprootAddress("tb", "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47Zagq");
     }
 
     function testParseBTCTaprootAddress12() public {
         vm.expectRevert();
-        deriver.parseBTCTaprootAddress(
-            "bc",
-            "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v07qwwzcrf"
-        );
+        deriver.parseBTCTaprootAddress("bc", "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v07qwwzcrf");
     }
 
     function testParseBTCTaprootAddress13() public {
         vm.expectRevert();
-        deriver.parseBTCTaprootAddress(
-            "tb",
-            "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vpggkg4j"
-        );
+        deriver.parseBTCTaprootAddress("tb", "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vpggkg4j");
     }
 
     function testParseBTCTaprootAddress14() public {
         vm.expectRevert();
-        deriver.parseBTCTaprootAddress(
-            "bc",
-            "bc1gmk9yu"
-        );
+        deriver.parseBTCTaprootAddress("bc", "bc1gmk9yu");
     }
 
-    function testParseBTCTaprootAddress15() public view{
-        (uint256 x, uint256 y) = deriver.parseBTCTaprootAddress(
-            "bc",
-            "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0"
-        );
-        assertEq(
-            x,
-            0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798
-        );
-        assertEq(
-            y,
-            0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8
-        );
+    function testParseBTCTaprootAddress15() public view {
+        (uint256 x, uint256 y) =
+            deriver.parseBTCTaprootAddress("bc", "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0");
+        assertEq(x, 0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798);
+        assertEq(y, 0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8);
     }
 
-    function testParseBTCTaprootAddress16() public view{
-        (uint256 x, uint256 y) = deriver.parseBTCTaprootAddress(
-            "tb",
-            "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c"
-        );
-        assertEq(
-            x,
-            0xC4A5CAD46221B2A187905E5266362B99D5E91C6CE24D165DAB93E86433
-        );
-        assertEq(
-            y,
-            0xE938F4061E36DEF24C05DDCFD738363AAFF7BBC09267C7079451A0F169500766
-        );
+    function testParseBTCTaprootAddress16() public view {
+        (uint256 x, uint256 y) =
+            deriver.parseBTCTaprootAddress("tb", "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c");
+        assertEq(x, 0xC4A5CAD46221B2A187905E5266362B99D5E91C6CE24D165DAB93E86433);
+        assertEq(y, 0xE938F4061E36DEF24C05DDCFD738363AAFF7BBC09267C7079451A0F169500766);
     }
 
-    function testParseBTCTaprootAddress17() public view{
-        (uint256 x, uint256 y) = deriver.parseBTCTaprootAddress(
-            "bc",
-            "bc1pldma57nkrdrvtx7elspzgfa23qcxglzzunxxmqkwq8pnwpa4sd6s3406mu"
-        );
-        assertEq(
-            x,
-            0xFB77DA7A761B46C59BD9FC022427AA8830647C42E4CC6D82CE01C33707B58375
-        );
-        assertEq(
-            y,
-            0x68251ED41C7645E4AE49F68B0F4A207E4327501CB0B4BB7E3F5D86EF815794C6
-        );
+    function testParseBTCTaprootAddress17() public view {
+        (uint256 x, uint256 y) =
+            deriver.parseBTCTaprootAddress("bc", "bc1pldma57nkrdrvtx7elspzgfa23qcxglzzunxxmqkwq8pnwpa4sd6s3406mu");
+        assertEq(x, 0xFB77DA7A761B46C59BD9FC022427AA8830647C42E4CC6D82CE01C33707B58375);
+        assertEq(y, 0x68251ED41C7645E4AE49F68B0F4A207E4327501CB0B4BB7E3F5D86EF815794C6);
         //console.log("pubkey:", x, y);
     }
 
@@ -195,147 +121,88 @@ contract BTCDepositAddressDeriverTest is Test {
 
         vm.expectEmit(address(deriver));
         emit BTCDepositAddressDeriver.SeedChanged(
-            "tb1p7g532zgvuzv8fz3hs02wvn2almqh8qyvz4xdr564nannkxh28kdq62ewy3",
-            "tb"
+            "tb1p7g532zgvuzv8fz3hs02wvn2almqh8qyvz4xdr564nannkxh28kdq62ewy3", "tb"
         );
         deriver.setSeed(
-            "tb1p7g532zgvuzv8fz3hs02wvn2almqh8qyvz4xdr564nannkxh28kdq62ewy3",
-            BitcoinNetworkEncoder.Network.Testnet
+            "tb1p7g532zgvuzv8fz3hs02wvn2almqh8qyvz4xdr564nannkxh28kdq62ewy3", BitcoinNetworkEncoder.Network.Testnet
         );
 
         assertEq(deriver.wasSeedSet(), true);
-        assertEq(
-            deriver.btcAddr(),
-            "tb1p7g532zgvuzv8fz3hs02wvn2almqh8qyvz4xdr564nannkxh28kdq62ewy3"
-        );
+        assertEq(deriver.btcAddr(), "tb1p7g532zgvuzv8fz3hs02wvn2almqh8qyvz4xdr564nannkxh28kdq62ewy3");
         assertEq(deriver.networkHrp(), "tb");
-        assertEq(
-            deriver.p1x(),
-            0xF22915090CE098748A3783D4E64D5DFEC173808C154CD1D3559F673B1AEA3D9A
-        );
-        assertEq(
-            deriver.p1y(),
-            0xEE340CB6B7C08A2B96B7C34A70B5B980FAD90AD4E9D0BE50302DA7542A73C0E0
-        );
+        assertEq(deriver.p1x(), 0xF22915090CE098748A3783D4E64D5DFEC173808C154CD1D3559F673B1AEA3D9A);
+        assertEq(deriver.p1y(), 0xEE340CB6B7C08A2B96B7C34A70B5B980FAD90AD4E9D0BE50302DA7542A73C0E0);
     }
 
     function testGetBTCDepositAddress_0_mainnet() public {
         deriver.setSeed(
-            "bc1pw7mg62ewhyap63q33n8zhaq2suxp8veukt7rfl63a4r5uarlxeaqdvrymq",
-            BitcoinNetworkEncoder.Network.Mainnet
+            "bc1pw7mg62ewhyap63q33n8zhaq2suxp8veukt7rfl63a4r5uarlxeaqdvrymq", BitcoinNetworkEncoder.Network.Mainnet
         );
 
-        string memory btcAddress = deriver.getBTCDepositAddress(
-            1
-        );
-        assertEq(
-            btcAddress,
-            "bc1pd2f6wg0g7hlxesjxvxqw7mqlk8pglusrvvjck9fz45epz487ay7qpaeqrf"
-        );
+        string memory btcAddress = deriver.getBTCDepositAddress(1);
+        assertEq(btcAddress, "bc1pd2f6wg0g7hlxesjxvxqw7mqlk8pglusrvvjck9fz45epz487ay7qpaeqrf");
     }
 
     function testGetBTCDepositAddress_0_testnet() public {
         deriver.setSeed(
-            "tb1pw7mg62ewhyap63q33n8zhaq2suxp8veukt7rfl63a4r5uarlxeaq6y4tp0",
-            BitcoinNetworkEncoder.Network.Testnet
+            "tb1pw7mg62ewhyap63q33n8zhaq2suxp8veukt7rfl63a4r5uarlxeaq6y4tp0", BitcoinNetworkEncoder.Network.Testnet
         );
 
-        string memory btcAddress = deriver.getBTCDepositAddress(
-            1
-        );
-        assertEq(
-            btcAddress,
-            "tb1pd2f6wg0g7hlxesjxvxqw7mqlk8pglusrvvjck9fz45epz487ay7qk400ex"
-        );
+        string memory btcAddress = deriver.getBTCDepositAddress(1);
+        assertEq(btcAddress, "tb1pd2f6wg0g7hlxesjxvxqw7mqlk8pglusrvvjck9fz45epz487ay7qk400ex");
     }
 
     function testGetBTCDepositAddress_0_regtest() public {
         deriver.setSeed(
-            "bcrt1pw7mg62ewhyap63q33n8zhaq2suxp8veukt7rfl63a4r5uarlxeaqhald54",
-            BitcoinNetworkEncoder.Network.Regtest
+            "bcrt1pw7mg62ewhyap63q33n8zhaq2suxp8veukt7rfl63a4r5uarlxeaqhald54", BitcoinNetworkEncoder.Network.Regtest
         );
 
-        string memory btcAddress = deriver.getBTCDepositAddress(
-            1
-        );
-        assertEq(
-            btcAddress,
-            "bcrt1pd2f6wg0g7hlxesjxvxqw7mqlk8pglusrvvjck9fz45epz487ay7qmv9fvu"
-        );
+        string memory btcAddress = deriver.getBTCDepositAddress(1);
+        assertEq(btcAddress, "bcrt1pd2f6wg0g7hlxesjxvxqw7mqlk8pglusrvvjck9fz45epz487ay7qmv9fvu");
     }
 
     function testGetBTCDepositAddress_0_simnet() public {
         deriver.setSeed(
-            "sb1pw7mg62ewhyap63q33n8zhaq2suxp8veukt7rfl63a4r5uarlxeaqa4lvc2",
-            BitcoinNetworkEncoder.Network.Simnet
+            "sb1pw7mg62ewhyap63q33n8zhaq2suxp8veukt7rfl63a4r5uarlxeaqa4lvc2", BitcoinNetworkEncoder.Network.Simnet
         );
 
-        string memory btcAddress = deriver.getBTCDepositAddress(
-            1
-        );
-        assertEq(
-            btcAddress,
-            "sb1pd2f6wg0g7hlxesjxvxqw7mqlk8pglusrvvjck9fz45epz487ay7q3y9gqr"
-        );
+        string memory btcAddress = deriver.getBTCDepositAddress(1);
+        assertEq(btcAddress, "sb1pd2f6wg0g7hlxesjxvxqw7mqlk8pglusrvvjck9fz45epz487ay7q3y9gqr");
     }
 
     function testGetBTCDepositAddress_1_mainnet() public {
         deriver.setSeed(
-            "bc1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs5pgpxg",
-            BitcoinNetworkEncoder.Network.Mainnet
+            "bc1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs5pgpxg", BitcoinNetworkEncoder.Network.Mainnet
         );
 
-        string memory btcAddress = deriver.getBTCDepositAddress(
-            1
-        );
-        assertEq(
-            btcAddress,
-            "bc1p376ekk9v5jhtg7kgtmn84pv8meeynwln72v9rr3pnswj9ks87khs8txv5u"
-        );
+        string memory btcAddress = deriver.getBTCDepositAddress(1);
+        assertEq(btcAddress, "bc1p376ekk9v5jhtg7kgtmn84pv8meeynwln72v9rr3pnswj9ks87khs8txv5u");
     }
 
     function testGetBTCDepositAddress_1_testnet() public {
         deriver.setSeed(
-            "tb1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsrf7wu8",
-            BitcoinNetworkEncoder.Network.Testnet
+            "tb1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsrf7wu8", BitcoinNetworkEncoder.Network.Testnet
         );
 
-        string memory btcAddress = deriver.getBTCDepositAddress(
-            1
-        );
-        assertEq(
-            btcAddress,
-            "tb1p376ekk9v5jhtg7kgtmn84pv8meeynwln72v9rr3pnswj9ks87khssrsrwn"
-        );
+        string memory btcAddress = deriver.getBTCDepositAddress(1);
+        assertEq(btcAddress, "tb1p376ekk9v5jhtg7kgtmn84pv8meeynwln72v9rr3pnswj9ks87khssrsrwn");
     }
 
     function testGetBTCDepositAddress_1_regtest() public {
         deriver.setSeed(
-            "bcrt1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsws5gfa",
-            BitcoinNetworkEncoder.Network.Regtest
+            "bcrt1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsws5gfa", BitcoinNetworkEncoder.Network.Regtest
         );
 
-        string memory btcAddress = deriver.getBTCDepositAddress(
-            1
-        );
-        assertEq(
-            btcAddress,
-            "bcrt1p376ekk9v5jhtg7kgtmn84pv8meeynwln72v9rr3pnswj9ks87khsa669mf"
-        );
+        string memory btcAddress = deriver.getBTCDepositAddress(1);
+        assertEq(btcAddress, "bcrt1p376ekk9v5jhtg7kgtmn84pv8meeynwln72v9rr3pnswj9ks87khsa669mf");
     }
 
     function testGetBTCDepositAddress_1_simnet() public {
         deriver.setSeed(
-            "sb1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsyc5f9z",
-            BitcoinNetworkEncoder.Network.Simnet
+            "sb1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsyc5f9z", BitcoinNetworkEncoder.Network.Simnet
         );
 
-        string memory btcAddress = deriver.getBTCDepositAddress(
-            1
-        );
-        assertEq(
-            btcAddress,
-            "sb1p376ekk9v5jhtg7kgtmn84pv8meeynwln72v9rr3pnswj9ks87khshj6yhk"
-        );
+        string memory btcAddress = deriver.getBTCDepositAddress(1);
+        assertEq(btcAddress, "sb1p376ekk9v5jhtg7kgtmn84pv8meeynwln72v9rr3pnswj9ks87khshj6yhk");
     }
 }

--- a/test/Deriver.t.sol
+++ b/test/Deriver.t.sol
@@ -6,107 +6,16 @@ import {Test, console} from "forge-std/Test.sol";
 import {Deriver} from "../src/Deriver.sol";
 
 contract DeriverTest is Test {
-    function testDerivationPubkey() public pure {
-        (uint256 x1, uint256 y1) = Deriver.getCombinedPubkey(
-            0xF22915090CE098748A3783D4E64D5DFEC173808C154CD1D3559F673B1AEA3D9A,
-            0xEE340CB6B7C08A2B96B7C34A70B5B980FAD90AD4E9D0BE50302DA7542A73C0E0,
-            0x8243BB6987C31A7B0EA36B7AFF9D0E24EAA6508997C16BCF83C84688517CE6EC,
-            0x4FEF9EF44EA93A90E91CB9ED229F0D684F6A56EBB0787174369D4DADDCB1A85C,
-            0xAF0AAFE2C1B97A6F64A78BD31CC1ABECC70623D61EB8D92231E0906AD5D2F739,
-            0x71A862373EF0DBB8489B1CE31E0D6F931A5C5AFA2D63FEA663FFAB45D7D467AA
-        );
-        assertEq(
-            x1,
-            0x786BA0CC9B0DA200D11CC085D41BBD5F1471DF8DF216CD775B924F4CAC80F341
-        );
-        assertEq(
-            y1,
-            0xD351E3FE211B48C6A8C8421F25767ED5D29F7E66944EB5DCD98F47DAF769F897
-        );
-    }
-
-    function testCoefficientDerivation() public pure {
-        uint256 c1 = Deriver.getCoefficient(
-            0xF22915090CE098748A3783D4E64D5DFEC173808C154CD1D3559F673B1AEA3D9A,
-            0xEE340CB6B7C08A2B96B7C34A70B5B980FAD90AD4E9D0BE50302DA7542A73C0E0,
-            0x71C7656EC7ab88b098defB751B7401B5f6d8976F
-        );
-        assertEq(
-            c1,
-            0x5FD0C009DA282DFE7E047C2190B3F00FF04E58B42F715D5345EBA4CD5BF4DBF9
-        );
-
-        uint256 c2 = Deriver.getCoefficient(
-            0x8243BB6987C31A7B0EA36B7AFF9D0E24EAA6508997C16BCF83C84688517CE6EC,
-            0x4FEF9EF44EA93A90E91CB9ED229F0D684F6A56EBB0787174369D4DADDCB1A85C,
-            0x71C7656EC7ab88b098defB751B7401B5f6d8976F
-        );
-        assertEq(
-            c2,
-            0xA55B9626A950D34CCAD73EEB13E3510861C6B4C9462668627F1A7DE500B6A1AB
-        );
-    }
-
-    function testCoefficientDerivation_2() public pure {
-        uint256 x_0 = 1;
-        uint256 y_0 = 29896722852569046015560700294576055776214335159245303116488692907525646231534;
-        address ethAddr_0 = 0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5;
-        uint256 expectedCoef_0 = 0x8e42e5c13f5cbeb86d71b7da134e17815a8d2679b58ac62bf77c0bcda88af048;
-        uint256 coef_0 = Deriver.getCoefficient(x_0, y_0, ethAddr_0);
-        assertEq(expectedCoef_0, coef_0);
-
-        uint256 x_1 = 100000001;
-        uint256 y_1 = 6187697718246333927483135664988668927828752610007079514140924362238612640234;
-        address ethAddr_1 = 0x4675C7e5BaAFBFFbca748158bEcBA61ef3b0a263;
-        uint256 expectedCoef_1 = 0xe57b99b605b15585b06b5111e5bf25f625fa0883a5a5dbe39630e09fa0333fc7;
-        uint256 coef_1 = Deriver.getCoefficient(x_1, y_1, ethAddr_1);
-        assertEq(expectedCoef_1, coef_1);
-
-        uint256 x_2 = 10000000000000001;
-        uint256 y_2 = 19058164647355796972794349987072136692774271288946368805784800428345550206840;
-        address ethAddr_2 = 0x9c595f9518b11b2876B2A5E89996B1Fd2c748726;
-        uint256 expectedCoef_2 = 0x836fc7d9c5288be60128dda0a3f5b6b48d5aac1eff1b248b259fd19caaa78192;
-        uint256 coef_2 = Deriver.getCoefficient(x_2, y_2, ethAddr_2);
-        assertEq(expectedCoef_2, coef_2);
-
-        uint256 x_3 = 49638490350653890404049973095656032488753139080487109443386992570973932368088;
-        uint256 y_3 = 55561757371571341431703784879667865348336433843616233757864721735452092825326;
-        address ethAddr_3 = 0x36A35fB10d9d273da615f4b658829901326e0d00;
-        uint256 expectedCoef_3 = 0x5d36326d019bc25f9f3119b630890fc745d72fdff1928f858194ce87b2be57a1;
-        uint256 coef_3 = Deriver.getCoefficient(x_3, y_3, ethAddr_3);
-        assertEq(expectedCoef_3, coef_3);
-    }
-
-    function testPubkeyFromAddree() public pure {
-        (uint256 x, uint256 y) = Deriver.getPubkeyFromAddress(
-            0xF22915090CE098748A3783D4E64D5DFEC173808C154CD1D3559F673B1AEA3D9A,
-            0xEE340CB6B7C08A2B96B7C34A70B5B980FAD90AD4E9D0BE50302DA7542A73C0E0,
-            0x8243BB6987C31A7B0EA36B7AFF9D0E24EAA6508997C16BCF83C84688517CE6EC,
-            0x4FEF9EF44EA93A90E91CB9ED229F0D684F6A56EBB0787174369D4DADDCB1A85C,
-            0x71C7656EC7ab88b098defB751B7401B5f6d8976F
-        );
-        assertEq(
-            x,
-            0xF841B419521509E6C50754F2801D94FA3F25D62AA2F55039DA1F7A848FDF7BBD
-        );
-        assertEq(
-            y,
-            0xB2445FEAA4E63449F7770E56C153A997F4E1B75707B7BF44ED4B69DEFAFD6813
-        );
-    }
-
     function testGetBtcAddressFromEth() public pure {
-        string memory btcAddress = Deriver.getBtcAddressTaprootNoScriptFromEth(
+        string memory btcAddress = Deriver.deriveReceivingAddressFromIndex(
             0xF22915090CE098748A3783D4E64D5DFEC173808C154CD1D3559F673B1AEA3D9A,
             0xEE340CB6B7C08A2B96B7C34A70B5B980FAD90AD4E9D0BE50302DA7542A73C0E0,
-            0x8243BB6987C31A7B0EA36B7AFF9D0E24EAA6508997C16BCF83C84688517CE6EC,
-            0x4FEF9EF44EA93A90E91CB9ED229F0D684F6A56EBB0787174369D4DADDCB1A85C,
-            bytes("tb"),
-            0x71C7656EC7ab88b098defB751B7401B5f6d8976F
+            1,
+            bytes("tb")
         );
         assertEq(
             btcAddress,
-            "tb1purjtasss2e7qsw6dyw54zf29t54t26u0l4hcyaruq472r83naces8c8k6h"
+            "tb1p9wmmnqqf57j58e8wym6gpcx52x7uvq4u6n58007nwruy7ga629sqzj487d"
         );
     }
 
@@ -236,77 +145,54 @@ contract DeriverTest is Test {
 
         uint256 x1_0 = 54147769457631533710022564500742536038246727812137618871549590227497793828474;
         uint256 y1_0 = 96091192197178033512370658560500964796461556892477693557977072200584849793968;
-        uint256 x2_0 = 67261561909726473286993603243929025817028541803191223835743288887468871643510;
-        uint256 y2_0 = 49473559344142397756767891385407723329456329883991697784595543981689192800614;
-        address ethAddr_0 = 0x388C818CA8B9251b393131C08a736A67ccB19297;
+        uint256 index0 = 1;
+
         string
-            memory expectedBtcAddr_0 = "bcrt1paz50paqaeph7xecyt8hzc9ly3sfyuaw0nmaaahat8mn37hrlhcjq5cm0kq";
-        // string
-        //     memory expectedBtcDesc_0 = "tr(73e0ef552f3e3a4b1b35d1be0476107fb060afb49634ef5ef22ac54171ff0541)";
-        string memory btcAddr_0 = Deriver.getBtcAddressTaprootNoScriptFromEth(
+            memory expectedBtcAddr_0 = "bcrt1pd2f6wg0g7hlxesjxvxqw7mqlk8pglusrvvjck9fz45epz487ay7qmv9fvu";
+        string memory btcAddr_0 = Deriver.deriveReceivingAddressFromIndex(
             x1_0,
             y1_0,
-            x2_0,
-            y2_0,
-            bytes("bcrt"),
-            ethAddr_0
+            index0,
+            bytes("bcrt")
         );
         assertEq(expectedBtcAddr_0, btcAddr_0);
 
         uint256 x1_1 = 1;
         uint256 y1_1 = 29896722852569046015560700294576055776214335159245303116488692907525646231534;
-        uint256 x2_1 = 109425434543890623006875089384956782646038918384464063743018502921509251658712;
-        uint256 y2_1 = 105040070358470594764068890032032104493554430042352852644935734267919855545570;
-        address ethAddr_1 = 0x5e17BFfaD9f5D57Bcc17071aec4249C9176A728d;
+        uint256 index1 = 1;
         string
-            memory expectedBtcAddr_1 = "bcrt1pc5ydppgpkeg5nrcetqu8g0rjeytsqww3j6xq50tlulqvwnfhhxcslync0s";
-        // string
-        //     memory expectedBtcDesc_1 = "tr(9829a5f5185b5556d42ee4fcd80cceabacc6abd6eea3904b0d95547b265a6b80)";
-        string memory btcAddr_1 = Deriver.getBtcAddressTaprootNoScriptFromEth(
+            memory expectedBtcAddr_1 = "bcrt1p376ekk9v5jhtg7kgtmn84pv8meeynwln72v9rr3pnswj9ks87khsa669mf";
+        string memory btcAddr_1 = Deriver.deriveReceivingAddressFromIndex(
             x1_1,
             y1_1,
-            x2_1,
-            y2_1,
-            bytes("bcrt"),
-            ethAddr_1
+            index1,
+            bytes("bcrt")
         );
         assertEq(expectedBtcAddr_1, btcAddr_1);
 
         uint256 x1_2 = 1004;
         uint256 y1_2 = 50566750680002108827280051043316308483979214535572331408301622620618248094164;
-        uint256 x2_2 = 59175011958650668134192622663723128104568439824145117716282659597024212199440;
-        uint256 y2_2 = 80820378799967249230036383627285913857484256274800501889702018267851848282858;
-        address ethAddr_2 = 0x5e17BFfaD9f5D57Bcc17071aec4249C9176A728d;
+        uint256 index2 = 1;
         string
-            memory expectedBtcAddr_2 = "bcrt1pu8e52ej8y50hdmnpzmusnxp8dxxa4nkp80l6n9k6vt2jm9matxaqtseyv9";
-        // string
-        //     memory expectedBtcDesc_2 = "tr(1c8abe597846aca60ecbc845dc921303a5ee52af29f235c985e93eca4d8f19bd)";
-        string memory btcAddr_2 = Deriver.getBtcAddressTaprootNoScriptFromEth(
+            memory expectedBtcAddr_2 = "bcrt1p0j9zken4lt69ap4xpckwm7a5awp4w77ys5ht75836zq7drl8ydaq6j2tsm";
+        string memory btcAddr_2 = Deriver.deriveReceivingAddressFromIndex(
             x1_2,
             y1_2,
-            x2_2,
-            y2_2,
-            bytes("bcrt"),
-            ethAddr_2
+            index2,
+            bytes("bcrt")
         );
         assertEq(expectedBtcAddr_2, btcAddr_2);
 
         uint256 x1_3 = 12;
         uint256 y1_3 = 31068864722486242021761838950999795945745157936084027215252040495978276421796;
-        uint256 x2_3 = 1;
-        uint256 y2_3 = 29896722852569046015560700294576055776214335159245303116488692907525646231534;
-        address ethAddr_3 = 0x5e17BFfaD9f5D57Bcc17071aec4249C9176A728d;
+        uint256 index3 = 1;
         string
-            memory expectedBtcAddr_3 = "bcrt1pfufcg3vafamdnfgtl95r7fwxln0457n8dlrz0crw99swzkp0ddms7z2lqx";
-        // string
-        //     memory expectedBtcDesc_3 = "tr(1fd8ab78bb02e83d42076c7615920e03597171c67237bff548bc3eae6f9d0051)";
-        string memory btcAddr_3 = Deriver.getBtcAddressTaprootNoScriptFromEth(
+            memory expectedBtcAddr_3 = "bcrt1pv6kne9rdn5kduyfe5svs27f7rv4etcs9w8yyy9jkuf659u68j97qux75zj";
+        string memory btcAddr_3 = Deriver.deriveReceivingAddressFromIndex(
             x1_3,
             y1_3,
-            x2_3,
-            y2_3,
-            bytes("bcrt"),
-            ethAddr_3
+            index3,
+            bytes("bcrt")
         );
         assertEq(expectedBtcAddr_3, btcAddr_3);
     }

--- a/test/LegacyBTCDepositAddressDeriver.t.sol
+++ b/test/LegacyBTCDepositAddressDeriver.t.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.27;
+pragma solidity ^0.8.27;
 
 import {console} from "forge-std/console.sol";
 import {Test} from "forge-std/Test.sol";
-import {BTCDepositAddressDeriver} from "../src/BTCDepositAddressDeriver.sol";
+import {LegacyBTCDepositAddressDeriver} from "../src/LegacyBTCDepositAddressDeriver.sol";
 import {BitcoinNetworkEncoder} from "../src/BitcoinNetworkEncoder.sol";
 
-contract BTCDepositAddressDeriverTest is Test {
-    BTCDepositAddressDeriver deriver;
+contract LegacyBTCDepositAddressDeriverTest is Test {
+    LegacyBTCDepositAddressDeriver deriver;
 
     function setUp() public {
-        deriver = new BTCDepositAddressDeriver();
+        deriver = new LegacyBTCDepositAddressDeriver();
     }
 
     function testParseBTCTaprootAddress1() public view{
@@ -188,25 +188,34 @@ contract BTCDepositAddressDeriverTest is Test {
 
     function testSetSeed() public {
         assertEq(deriver.wasSeedSet(), false);
-        assertEq(deriver.btcAddr(), "");
+        assertEq(deriver.btcAddr1(), "");
+        assertEq(deriver.btcAddr2(), "");
         assertEq(deriver.networkHrp(), "");
         assertEq(deriver.p1x(), 0);
         assertEq(deriver.p1y(), 0);
+        assertEq(deriver.p2x(), 0);
+        assertEq(deriver.p2y(), 0);
 
         vm.expectEmit(address(deriver));
-        emit BTCDepositAddressDeriver.SeedChanged(
+        emit LegacyBTCDepositAddressDeriver.SeedChanged(
             "tb1p7g532zgvuzv8fz3hs02wvn2almqh8qyvz4xdr564nannkxh28kdq62ewy3",
+            "tb1psfpmk6v8cvd8kr4rdda0l8gwyn42v5yfjlqkhnureprgs5tuumkqvdkewz",
             "tb"
         );
         deriver.setSeed(
             "tb1p7g532zgvuzv8fz3hs02wvn2almqh8qyvz4xdr564nannkxh28kdq62ewy3",
+            "tb1psfpmk6v8cvd8kr4rdda0l8gwyn42v5yfjlqkhnureprgs5tuumkqvdkewz",
             BitcoinNetworkEncoder.Network.Testnet
         );
 
         assertEq(deriver.wasSeedSet(), true);
         assertEq(
-            deriver.btcAddr(),
+            deriver.btcAddr1(),
             "tb1p7g532zgvuzv8fz3hs02wvn2almqh8qyvz4xdr564nannkxh28kdq62ewy3"
+        );
+        assertEq(
+            deriver.btcAddr2(),
+            "tb1psfpmk6v8cvd8kr4rdda0l8gwyn42v5yfjlqkhnureprgs5tuumkqvdkewz"
         );
         assertEq(deriver.networkHrp(), "tb");
         assertEq(
@@ -217,125 +226,173 @@ contract BTCDepositAddressDeriverTest is Test {
             deriver.p1y(),
             0xEE340CB6B7C08A2B96B7C34A70B5B980FAD90AD4E9D0BE50302DA7542A73C0E0
         );
+        assertEq(
+            deriver.p2x(),
+            0x8243BB6987C31A7B0EA36B7AFF9D0E24EAA6508997C16BCF83C84688517CE6EC
+        );
+        assertEq(
+            deriver.p2y(),
+            0x4FEF9EF44EA93A90E91CB9ED229F0D684F6A56EBB0787174369D4DADDCB1A85C
+        );
     }
 
+    // This test was generated automatically in Go.
+    // pk1: 77b68d2b2eb93a1d44118cce2bf40a870c13b33cb2fc34ff51ed474e747f367a
+    // pk2: 94b4b1e7676caf70c0c07ceb84c723fce2099689efcd741a852598086043f176
+    // resulting descriptor: tr(73e0ef552f3e3a4b1b35d1be0476107fb060afb49634ef5ef22ac54171ff0541)
     function testGetBTCDepositAddress_0_mainnet() public {
         deriver.setSeed(
             "bc1pw7mg62ewhyap63q33n8zhaq2suxp8veukt7rfl63a4r5uarlxeaqdvrymq",
+            "bc1pjj6trem8djhhpsxq0n4cf3erln3qn95falxhgx59ykvqsczr79mqnuzsa3",
             BitcoinNetworkEncoder.Network.Mainnet
         );
 
         string memory btcAddress = deriver.getBTCDepositAddress(
-            1
+            0x388C818CA8B9251b393131C08a736A67ccB19297
         );
         assertEq(
             btcAddress,
-            "bc1pd2f6wg0g7hlxesjxvxqw7mqlk8pglusrvvjck9fz45epz487ay7qpaeqrf"
+            "bc1paz50paqaeph7xecyt8hzc9ly3sfyuaw0nmaaahat8mn37hrlhcjqwf8xe4"
         );
     }
 
+    // This test was generated automatically in Go.
+    // pk1: 77b68d2b2eb93a1d44118cce2bf40a870c13b33cb2fc34ff51ed474e747f367a
+    // pk2: 94b4b1e7676caf70c0c07ceb84c723fce2099689efcd741a852598086043f176
+    // resulting descriptor: tr(73e0ef552f3e3a4b1b35d1be0476107fb060afb49634ef5ef22ac54171ff0541)
     function testGetBTCDepositAddress_0_testnet() public {
         deriver.setSeed(
             "tb1pw7mg62ewhyap63q33n8zhaq2suxp8veukt7rfl63a4r5uarlxeaq6y4tp0",
+            "tb1pjj6trem8djhhpsxq0n4cf3erln3qn95falxhgx59ykvqsczr79mqy55l87",
             BitcoinNetworkEncoder.Network.Testnet
         );
 
         string memory btcAddress = deriver.getBTCDepositAddress(
-            1
+            0x388C818CA8B9251b393131C08a736A67ccB19297
         );
         assertEq(
             btcAddress,
-            "tb1pd2f6wg0g7hlxesjxvxqw7mqlk8pglusrvvjck9fz45epz487ay7qk400ex"
+            "tb1paz50paqaeph7xecyt8hzc9ly3sfyuaw0nmaaahat8mn37hrlhcjqep3fr6"
         );
     }
 
+    // This test was generated automatically in Go.
+    // pk1: 77b68d2b2eb93a1d44118cce2bf40a870c13b33cb2fc34ff51ed474e747f367a
+    // pk2: 94b4b1e7676caf70c0c07ceb84c723fce2099689efcd741a852598086043f176
+    // resulting descriptor: tr(73e0ef552f3e3a4b1b35d1be0476107fb060afb49634ef5ef22ac54171ff0541)
     function testGetBTCDepositAddress_0_regtest() public {
         deriver.setSeed(
             "bcrt1pw7mg62ewhyap63q33n8zhaq2suxp8veukt7rfl63a4r5uarlxeaqhald54",
+            "bcrt1pjj6trem8djhhpsxq0n4cf3erln3qn95falxhgx59ykvqsczr79mqfd7ejy",
             BitcoinNetworkEncoder.Network.Regtest
         );
 
         string memory btcAddress = deriver.getBTCDepositAddress(
-            1
+            0x388C818CA8B9251b393131C08a736A67ccB19297
         );
         assertEq(
             btcAddress,
-            "bcrt1pd2f6wg0g7hlxesjxvxqw7mqlk8pglusrvvjck9fz45epz487ay7qmv9fvu"
+            "bcrt1paz50paqaeph7xecyt8hzc9ly3sfyuaw0nmaaahat8mn37hrlhcjq5cm0kq"
         );
     }
 
+    // This test was generated automatically in Go.
+    // pk1: 77b68d2b2eb93a1d44118cce2bf40a870c13b33cb2fc34ff51ed474e747f367a
+    // pk2: 94b4b1e7676caf70c0c07ceb84c723fce2099689efcd741a852598086043f176
+    // resulting descriptor: tr(73e0ef552f3e3a4b1b35d1be0476107fb060afb49634ef5ef22ac54171ff0541)
     function testGetBTCDepositAddress_0_simnet() public {
         deriver.setSeed(
             "sb1pw7mg62ewhyap63q33n8zhaq2suxp8veukt7rfl63a4r5uarlxeaqa4lvc2",
+            "sb1pjj6trem8djhhpsxq0n4cf3erln3qn95falxhgx59ykvqsczr79mqr97c7m",
             BitcoinNetworkEncoder.Network.Simnet
         );
 
         string memory btcAddress = deriver.getBTCDepositAddress(
-            1
+            0x388C818CA8B9251b393131C08a736A67ccB19297
         );
         assertEq(
             btcAddress,
-            "sb1pd2f6wg0g7hlxesjxvxqw7mqlk8pglusrvvjck9fz45epz487ay7q3y9gqr"
+            "sb1paz50paqaeph7xecyt8hzc9ly3sfyuaw0nmaaahat8mn37hrlhcjq7smw6l"
         );
     }
 
+    // This test was generated automatically in Go.
+    // pk1: 0000000000000000000000000000000000000000000000000000000000000001
+    // pk2: f1ec99e484b7c7f31f22a19d6f8f59508abb3e86bdf8ff4d4f6afbd8bb4133d8
+    // resulting descriptor: tr(9829a5f5185b5556d42ee4fcd80cceabacc6abd6eea3904b0d95547b265a6b80)
     function testGetBTCDepositAddress_1_mainnet() public {
         deriver.setSeed(
             "bc1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs5pgpxg",
+            "bc1p78kfneyyklrlx8ez5xwklr6e2z9tk05xhhu07n20dtaa3w6px0vqa3ptvn",
             BitcoinNetworkEncoder.Network.Mainnet
         );
 
         string memory btcAddress = deriver.getBTCDepositAddress(
-            1
+            0x5e17BFfaD9f5D57Bcc17071aec4249C9176A728d
         );
         assertEq(
             btcAddress,
-            "bc1p376ekk9v5jhtg7kgtmn84pv8meeynwln72v9rr3pnswj9ks87khs8txv5u"
+            "bc1pc5ydppgpkeg5nrcetqu8g0rjeytsqww3j6xq50tlulqvwnfhhxcs9403q9"
         );
     }
 
+    // This test was generated automatically in Go.
+    // pk1: 0000000000000000000000000000000000000000000000000000000000000001
+    // pk2: f1ec99e484b7c7f31f22a19d6f8f59508abb3e86bdf8ff4d4f6afbd8bb4133d8
+    // resulting descriptor: tr(9829a5f5185b5556d42ee4fcd80cceabacc6abd6eea3904b0d95547b265a6b80)
     function testGetBTCDepositAddress_1_testnet() public {
         deriver.setSeed(
             "tb1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsrf7wu8",
+            "tb1p78kfneyyklrlx8ez5xwklr6e2z9tk05xhhu07n20dtaa3w6px0vq2ehyku",
             BitcoinNetworkEncoder.Network.Testnet
         );
 
         string memory btcAddress = deriver.getBTCDepositAddress(
-            1
+            0x5e17BFfaD9f5D57Bcc17071aec4249C9176A728d
         );
         assertEq(
             btcAddress,
-            "tb1p376ekk9v5jhtg7kgtmn84pv8meeynwln72v9rr3pnswj9ks87khssrsrwn"
+            "tb1pc5ydppgpkeg5nrcetqu8g0rjeytsqww3j6xq50tlulqvwnfhhxcsjae762"
         );
     }
 
+    // This test was generated automatically in Go.
+    // pk1: 0000000000000000000000000000000000000000000000000000000000000001
+    // pk2: f1ec99e484b7c7f31f22a19d6f8f59508abb3e86bdf8ff4d4f6afbd8bb4133d8
+    // resulting descriptor: tr(9829a5f5185b5556d42ee4fcd80cceabacc6abd6eea3904b0d95547b265a6b80)
     function testGetBTCDepositAddress_1_regtest() public {
         deriver.setSeed(
             "bcrt1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsws5gfa",
+            "bcrt1p78kfneyyklrlx8ez5xwklr6e2z9tk05xhhu07n20dtaa3w6px0vq8qazrx",
             BitcoinNetworkEncoder.Network.Regtest
         );
 
         string memory btcAddress = deriver.getBTCDepositAddress(
-            1
+            0x5e17BFfaD9f5D57Bcc17071aec4249C9176A728d
         );
         assertEq(
             btcAddress,
-            "bcrt1p376ekk9v5jhtg7kgtmn84pv8meeynwln72v9rr3pnswj9ks87khsa669mf"
+            "bcrt1pc5ydppgpkeg5nrcetqu8g0rjeytsqww3j6xq50tlulqvwnfhhxcslync0s"
         );
     }
 
+    // This test was generated automatically in Go.
+    // pk1: 0000000000000000000000000000000000000000000000000000000000000001
+    // pk2: f1ec99e484b7c7f31f22a19d6f8f59508abb3e86bdf8ff4d4f6afbd8bb4133d8
+    // resulting descriptor: tr(9829a5f5185b5556d42ee4fcd80cceabacc6abd6eea3904b0d95547b265a6b80)
     function testGetBTCDepositAddress_1_simnet() public {
         deriver.setSeed(
             "sb1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsyc5f9z",
+            "sb1p78kfneyyklrlx8ez5xwklr6e2z9tk05xhhu07n20dtaa3w6px0vqdgar0e",
             BitcoinNetworkEncoder.Network.Simnet
         );
 
         string memory btcAddress = deriver.getBTCDepositAddress(
-            1
+            0x5e17BFfaD9f5D57Bcc17071aec4249C9176A728d
         );
         assertEq(
             btcAddress,
-            "sb1p376ekk9v5jhtg7kgtmn84pv8meeynwln72v9rr3pnswj9ks87khshj6yhk"
+            "sb1pc5ydppgpkeg5nrcetqu8g0rjeytsqww3j6xq50tlulqvwnfhhxcs4vner0"
         );
     }
 }

--- a/test/LegacyDeriver.t.sol
+++ b/test/LegacyDeriver.t.sol
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.27;
+
+import {Test, console} from "forge-std/Test.sol";
+import {LegacyDeriver} from "../src/LegacyDeriver.sol";
+
+contract LegacyDeriverTest is Test {
+    function testDerivationPubkey() public pure {
+        (uint256 x1, uint256 y1) = LegacyDeriver.getCombinedPubkey(
+            0xF22915090CE098748A3783D4E64D5DFEC173808C154CD1D3559F673B1AEA3D9A,
+            0xEE340CB6B7C08A2B96B7C34A70B5B980FAD90AD4E9D0BE50302DA7542A73C0E0,
+            0x8243BB6987C31A7B0EA36B7AFF9D0E24EAA6508997C16BCF83C84688517CE6EC,
+            0x4FEF9EF44EA93A90E91CB9ED229F0D684F6A56EBB0787174369D4DADDCB1A85C,
+            0xAF0AAFE2C1B97A6F64A78BD31CC1ABECC70623D61EB8D92231E0906AD5D2F739,
+            0x71A862373EF0DBB8489B1CE31E0D6F931A5C5AFA2D63FEA663FFAB45D7D467AA
+        );
+        assertEq(
+            x1,
+            0x786BA0CC9B0DA200D11CC085D41BBD5F1471DF8DF216CD775B924F4CAC80F341
+        );
+        assertEq(
+            y1,
+            0xD351E3FE211B48C6A8C8421F25767ED5D29F7E66944EB5DCD98F47DAF769F897
+        );
+    }
+
+    function testCoefficientDerivation() public pure {
+        uint256 c1 = LegacyDeriver.getCoefficient(
+            0xF22915090CE098748A3783D4E64D5DFEC173808C154CD1D3559F673B1AEA3D9A,
+            0xEE340CB6B7C08A2B96B7C34A70B5B980FAD90AD4E9D0BE50302DA7542A73C0E0,
+            0x71C7656EC7ab88b098defB751B7401B5f6d8976F
+        );
+        assertEq(
+            c1,
+            0x5FD0C009DA282DFE7E047C2190B3F00FF04E58B42F715D5345EBA4CD5BF4DBF9
+        );
+
+        uint256 c2 = LegacyDeriver.getCoefficient(
+            0x8243BB6987C31A7B0EA36B7AFF9D0E24EAA6508997C16BCF83C84688517CE6EC,
+            0x4FEF9EF44EA93A90E91CB9ED229F0D684F6A56EBB0787174369D4DADDCB1A85C,
+            0x71C7656EC7ab88b098defB751B7401B5f6d8976F
+        );
+        assertEq(
+            c2,
+            0xA55B9626A950D34CCAD73EEB13E3510861C6B4C9462668627F1A7DE500B6A1AB
+        );
+    }
+
+    function testCoefficientDerivation_2() public pure {
+        uint256 x_0 = 1;
+        uint256 y_0 = 29896722852569046015560700294576055776214335159245303116488692907525646231534;
+        address ethAddr_0 = 0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5;
+        uint256 expectedCoef_0 = 0x8e42e5c13f5cbeb86d71b7da134e17815a8d2679b58ac62bf77c0bcda88af048;
+        uint256 coef_0 = LegacyDeriver.getCoefficient(x_0, y_0, ethAddr_0);
+        assertEq(expectedCoef_0, coef_0);
+
+        uint256 x_1 = 100000001;
+        uint256 y_1 = 6187697718246333927483135664988668927828752610007079514140924362238612640234;
+        address ethAddr_1 = 0x4675C7e5BaAFBFFbca748158bEcBA61ef3b0a263;
+        uint256 expectedCoef_1 = 0xe57b99b605b15585b06b5111e5bf25f625fa0883a5a5dbe39630e09fa0333fc7;
+        uint256 coef_1 = LegacyDeriver.getCoefficient(x_1, y_1, ethAddr_1);
+        assertEq(expectedCoef_1, coef_1);
+
+        uint256 x_2 = 10000000000000001;
+        uint256 y_2 = 19058164647355796972794349987072136692774271288946368805784800428345550206840;
+        address ethAddr_2 = 0x9c595f9518b11b2876B2A5E89996B1Fd2c748726;
+        uint256 expectedCoef_2 = 0x836fc7d9c5288be60128dda0a3f5b6b48d5aac1eff1b248b259fd19caaa78192;
+        uint256 coef_2 = LegacyDeriver.getCoefficient(x_2, y_2, ethAddr_2);
+        assertEq(expectedCoef_2, coef_2);
+
+        uint256 x_3 = 49638490350653890404049973095656032488753139080487109443386992570973932368088;
+        uint256 y_3 = 55561757371571341431703784879667865348336433843616233757864721735452092825326;
+        address ethAddr_3 = 0x36A35fB10d9d273da615f4b658829901326e0d00;
+        uint256 expectedCoef_3 = 0x5d36326d019bc25f9f3119b630890fc745d72fdff1928f858194ce87b2be57a1;
+        uint256 coef_3 = LegacyDeriver.getCoefficient(x_3, y_3, ethAddr_3);
+        assertEq(expectedCoef_3, coef_3);
+    }
+
+    function testPubkeyFromAddree() public pure {
+        (uint256 x, uint256 y) = LegacyDeriver.getPubkeyFromAddress(
+            0xF22915090CE098748A3783D4E64D5DFEC173808C154CD1D3559F673B1AEA3D9A,
+            0xEE340CB6B7C08A2B96B7C34A70B5B980FAD90AD4E9D0BE50302DA7542A73C0E0,
+            0x8243BB6987C31A7B0EA36B7AFF9D0E24EAA6508997C16BCF83C84688517CE6EC,
+            0x4FEF9EF44EA93A90E91CB9ED229F0D684F6A56EBB0787174369D4DADDCB1A85C,
+            0x71C7656EC7ab88b098defB751B7401B5f6d8976F
+        );
+        assertEq(
+            x,
+            0xF841B419521509E6C50754F2801D94FA3F25D62AA2F55039DA1F7A848FDF7BBD
+        );
+        assertEq(
+            y,
+            0xB2445FEAA4E63449F7770E56C153A997F4E1B75707B7BF44ED4B69DEFAFD6813
+        );
+    }
+
+    function testGetBtcAddressFromEth() public pure {
+        string memory btcAddress = LegacyDeriver.getBtcAddressTaprootNoScriptFromEth(
+            0xF22915090CE098748A3783D4E64D5DFEC173808C154CD1D3559F673B1AEA3D9A,
+            0xEE340CB6B7C08A2B96B7C34A70B5B980FAD90AD4E9D0BE50302DA7542A73C0E0,
+            0x8243BB6987C31A7B0EA36B7AFF9D0E24EAA6508997C16BCF83C84688517CE6EC,
+            0x4FEF9EF44EA93A90E91CB9ED229F0D684F6A56EBB0787174369D4DADDCB1A85C,
+            bytes("tb"),
+            0x71C7656EC7ab88b098defB751B7401B5f6d8976F
+        );
+        assertEq(
+            btcAddress,
+            "tb1purjtasss2e7qsw6dyw54zf29t54t26u0l4hcyaruq472r83naces8c8k6h"
+        );
+    }
+
+    function testComputeTaprootKeyNoScript() public pure {
+        // Test cases were automatically generated in Go.
+        // Correspondence between descriptor and regtest address was checked in bitcoind.
+
+        // small x=1 to check padding, FindPubkeyFromX(1)
+        // Descriptor: tr(0000000000000000000000000000000000000000000000000000000000000001)
+        // Regtest address: bcrt1pw3yacwv2cun92ke5g4gmyvzjxclucqx8t6tml7m0tfqjecvqtzks2sgz5f
+        uint256 x0 = 1;
+        uint256 y0 = 29896722852569046015560700294576055776214335159245303116488692907525646231534;
+        uint256 x0TweakedExpected = 52598790206915998760408158409706115969242582706983276613226717467982222612653;
+        uint256 y0TweakedExpected = 8539729109611639503272152634470558050354725767758305540483549745586427273314;
+        (uint256 x0Tweaked, uint256 y0Tweaked) = LegacyDeriver
+            .computeTaprootKeyNoScript(x0, y0);
+        assertEq(x0Tweaked, x0TweakedExpected);
+        assertEq(y0Tweaked, y0TweakedExpected);
+
+        // x(>=1000) to check padding, FindPubkeyFromX(1000)
+        // Descriptor: tr(00000000000000000000000000000000000000000000000000000000000003ec)
+        // Regtest address: bcrt1p5l79spdqw2swuwg9zvrjnw6ax5l03h5633prhz8qcr2rcm2gg3wspu4wej
+        uint256 x1 = 1004;
+        uint256 y1 = 50566750680002108827280051043316308483979214535572331408301622620618248094164;
+        uint256 x1TweakedExpected = 75982098679105012767054839615480766874362225667059272419725367141590016476253;
+        uint256 y1TweakedExpected = 38111558438345768766105231040238601022767042816083729768024884986909252148597;
+        (uint256 x1Tweaked, uint256 y1Tweaked) = LegacyDeriver
+            .computeTaprootKeyNoScript(x1, y1);
+        assertEq(x1Tweaked, x1TweakedExpected);
+        assertEq(y1Tweaked, y1TweakedExpected);
+
+        // x(>=1000000) to check padding, FindPubkeyFromX(1000000)
+        // Descriptor: tr(00000000000000000000000000000000000000000000000000000000000f4242)
+        // Regtest address: bcrt1p48s3pxlgdp9c804saz53fs7n5yxwrq882sr27xhdtvvkn0ajqj9qpncdwt
+        uint256 x2 = 1000002;
+        uint256 y2 = 115421580779160830541564858798348048665605890024245002666544848392484158543900;
+        uint256 x2TweakedExpected = 76838526631355794299542788514028170455259944725644477117600957851609725011082;
+        uint256 y2TweakedExpected = 61636608481388897341296123833809412111161299133548647817060478960764143138799;
+        (uint256 x2Tweaked, uint256 y2Tweaked) = LegacyDeriver
+            .computeTaprootKeyNoScript(x2, y2);
+        assertEq(x2Tweaked, x2TweakedExpected);
+        assertEq(y2Tweaked, y2TweakedExpected);
+
+        // x(>=1000000000) to check padding, FindPubkeyFromX(1000000000)
+        // Descriptor: tr(000000000000000000000000000000000000000000000000000000003b9aca03)
+        // Regtest address: bcrt1py4y0m4y4cape83840e9qy0u9mhn4mf44m0k6447k5klep6gyk03s29ts3h
+        uint256 x3 = 1000000003;
+        uint256 y3 = 40276071915510323673084110927775790363542425252812024751949404428417686863292;
+        uint256 x3TweakedExpected = 16864540259352835392870939686994004168658892970981429858603412376299126436835;
+        uint256 y3TweakedExpected = 62871895376343251820683844942076504881002674530470591206287079343301458236439;
+        (uint256 x3Tweaked, uint256 y3Tweaked) = LegacyDeriver
+            .computeTaprootKeyNoScript(x3, y3);
+        assertEq(x3Tweaked, x3TweakedExpected);
+        assertEq(y3Tweaked, y3TweakedExpected);
+
+        // some random key, GetPubkeyFromSeed("key-1")
+        // Descriptor: tr(d2574f8ea255f1ee32a7ba303fdf3ba0bcf5de9a765aec325179f0fed56147c8)
+        // Regtest address: bcrt1ptts7ukatnnp3v4uv8nl6ja4p3jgszpp2fjakkzjdmedru59m4qaslkngeu
+        uint256 x4 = 95139962980491431174412159539357321770091795886961022501559818261988217276360;
+        uint256 y4 = 46036297902870250637947206317417135133611687575579611582072758463587242207960;
+        uint256 x4TweakedExpected = 41107342049127684338865387735159753882100729519671631047080651435112102864955;
+        uint256 y4TweakedExpected = 39684114171189517446112675430978734680806571453129682454396918992690845153022;
+        (uint256 x4Tweaked, uint256 y4Tweaked) = LegacyDeriver
+            .computeTaprootKeyNoScript(x4, y4);
+        assertEq(x4Tweaked, x4TweakedExpected);
+        assertEq(y4Tweaked, y4TweakedExpected);
+
+        // some random key, GetPubkeyFromSeed("key-2")
+        // Descriptor: tr(e04cd7c61dd4ba8a0251ae6b55ae9a4f1adc5d1f2ca2db189bb6e913b58081be)
+        // Regtest address: bcrt1p4lkh3vc0yhd8yufkl4uzdztz2hla3t55jy7n9nl5yvzmhw8vnqlsasesls
+        uint256 x5 = 101453847676250396228413237673246898808317095937272786651400543244471507124670;
+        uint256 y5 = 63454576008186559064547728145704133169288740657138044079107482525695746136122;
+        uint256 x5TweakedExpected = 79574324293411419662104829151852572098189426134826193796410519409314306496575;
+        uint256 y5TweakedExpected = 84049350742986204533456594847398501395878693485889352338247467465353458662720;
+        (uint256 x5Tweaked, uint256 y5Tweaked) = LegacyDeriver
+            .computeTaprootKeyNoScript(x5, y5);
+        assertEq(x5Tweaked, x5TweakedExpected);
+        assertEq(y5Tweaked, y5TweakedExpected);
+    }
+
+    function testgetBtcTaprootAddrFromPubkey() public pure {
+        uint256 x0 = 1;
+        bytes memory hrp0 = bytes("bcrt");
+        string
+            memory expectedBtcAddr0 = "bcrt1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsws5gfa";
+        string memory btcAddr0 = LegacyDeriver.getBtcTaprootAddrFromPubkey(x0, hrp0);
+        assertEq(expectedBtcAddr0, btcAddr0);
+
+        uint256 x1 = 1004;
+        bytes memory hrp1 = bytes("bcrt");
+        string
+            memory expectedBtcAddr1 = "bcrt1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0kqgxaz3y";
+        string memory btcAddr1 = LegacyDeriver.getBtcTaprootAddrFromPubkey(x1, hrp1);
+        assertEq(expectedBtcAddr1, btcAddr1);
+
+        uint256 x2 = 1000002;
+        bytes memory hrp2 = bytes("bcrt");
+        string
+            memory expectedBtcAddr2 = "bcrt1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0gfpqk2l9fn";
+        string memory btcAddr2 = LegacyDeriver.getBtcTaprootAddrFromPubkey(x2, hrp2);
+        assertEq(expectedBtcAddr2, btcAddr2);
+
+        uint256 x3 = 1000000003;
+        bytes memory hrp3 = bytes("bcrt");
+        string
+            memory expectedBtcAddr3 = "bcrt1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqwu6egpskvk9c6";
+        string memory btcAddr3 = LegacyDeriver.getBtcTaprootAddrFromPubkey(x3, hrp3);
+        assertEq(expectedBtcAddr3, btcAddr3);
+
+        uint256 x4 = 49638490350653890404049973095656032488753139080487109443386992570973932368088;
+        bytes memory hrp4 = bytes("bcrt");
+        string
+            memory expectedBtcAddr4 = "bcrt1pdklx85f3ur9plklewyhwlk27au5xpwruxn96fymp3tq3y3zzxrvqzepnl7";
+        string memory btcAddr4 = LegacyDeriver.getBtcTaprootAddrFromPubkey(x4, hrp4);
+        assertEq(expectedBtcAddr4, btcAddr4);
+
+        uint256 x5 = 60127624607440319347311638604827610310097127916858217930208677047728575394005;
+        bytes memory hrp5 = bytes("bcrt");
+        string
+            memory expectedBtcAddr5 = "bcrt1psnhs0r3njpqqheauvx0a6thypn5m4p7uy6ue97w9cgma7wfckr2sdqa585";
+        string memory btcAddr5 = LegacyDeriver.getBtcTaprootAddrFromPubkey(x5, hrp5);
+        assertEq(expectedBtcAddr5, btcAddr5);
+    }
+
+    function testGetBtcAddressTaprootNoScriptFromEth() public pure {
+        // Test cases were automatically generated in Go.
+
+        uint256 x1_0 = 54147769457631533710022564500742536038246727812137618871549590227497793828474;
+        uint256 y1_0 = 96091192197178033512370658560500964796461556892477693557977072200584849793968;
+        uint256 x2_0 = 67261561909726473286993603243929025817028541803191223835743288887468871643510;
+        uint256 y2_0 = 49473559344142397756767891385407723329456329883991697784595543981689192800614;
+        address ethAddr_0 = 0x388C818CA8B9251b393131C08a736A67ccB19297;
+        string
+            memory expectedBtcAddr_0 = "bcrt1paz50paqaeph7xecyt8hzc9ly3sfyuaw0nmaaahat8mn37hrlhcjq5cm0kq";
+        // string
+        //     memory expectedBtcDesc_0 = "tr(73e0ef552f3e3a4b1b35d1be0476107fb060afb49634ef5ef22ac54171ff0541)";
+        string memory btcAddr_0 = LegacyDeriver.getBtcAddressTaprootNoScriptFromEth(
+            x1_0,
+            y1_0,
+            x2_0,
+            y2_0,
+            bytes("bcrt"),
+            ethAddr_0
+        );
+        assertEq(expectedBtcAddr_0, btcAddr_0);
+
+        uint256 x1_1 = 1;
+        uint256 y1_1 = 29896722852569046015560700294576055776214335159245303116488692907525646231534;
+        uint256 x2_1 = 109425434543890623006875089384956782646038918384464063743018502921509251658712;
+        uint256 y2_1 = 105040070358470594764068890032032104493554430042352852644935734267919855545570;
+        address ethAddr_1 = 0x5e17BFfaD9f5D57Bcc17071aec4249C9176A728d;
+        string
+            memory expectedBtcAddr_1 = "bcrt1pc5ydppgpkeg5nrcetqu8g0rjeytsqww3j6xq50tlulqvwnfhhxcslync0s";
+        // string
+        //     memory expectedBtcDesc_1 = "tr(9829a5f5185b5556d42ee4fcd80cceabacc6abd6eea3904b0d95547b265a6b80)";
+        string memory btcAddr_1 = LegacyDeriver.getBtcAddressTaprootNoScriptFromEth(
+            x1_1,
+            y1_1,
+            x2_1,
+            y2_1,
+            bytes("bcrt"),
+            ethAddr_1
+        );
+        assertEq(expectedBtcAddr_1, btcAddr_1);
+
+        uint256 x1_2 = 1004;
+        uint256 y1_2 = 50566750680002108827280051043316308483979214535572331408301622620618248094164;
+        uint256 x2_2 = 59175011958650668134192622663723128104568439824145117716282659597024212199440;
+        uint256 y2_2 = 80820378799967249230036383627285913857484256274800501889702018267851848282858;
+        address ethAddr_2 = 0x5e17BFfaD9f5D57Bcc17071aec4249C9176A728d;
+        string
+            memory expectedBtcAddr_2 = "bcrt1pu8e52ej8y50hdmnpzmusnxp8dxxa4nkp80l6n9k6vt2jm9matxaqtseyv9";
+        // string
+        //     memory expectedBtcDesc_2 = "tr(1c8abe597846aca60ecbc845dc921303a5ee52af29f235c985e93eca4d8f19bd)";
+        string memory btcAddr_2 = LegacyDeriver.getBtcAddressTaprootNoScriptFromEth(
+            x1_2,
+            y1_2,
+            x2_2,
+            y2_2,
+            bytes("bcrt"),
+            ethAddr_2
+        );
+        assertEq(expectedBtcAddr_2, btcAddr_2);
+
+        uint256 x1_3 = 12;
+        uint256 y1_3 = 31068864722486242021761838950999795945745157936084027215252040495978276421796;
+        uint256 x2_3 = 1;
+        uint256 y2_3 = 29896722852569046015560700294576055776214335159245303116488692907525646231534;
+        address ethAddr_3 = 0x5e17BFfaD9f5D57Bcc17071aec4249C9176A728d;
+        string
+            memory expectedBtcAddr_3 = "bcrt1pfufcg3vafamdnfgtl95r7fwxln0457n8dlrz0crw99swzkp0ddms7z2lqx";
+        // string
+        //     memory expectedBtcDesc_3 = "tr(1fd8ab78bb02e83d42076c7615920e03597171c67237bff548bc3eae6f9d0051)";
+        string memory btcAddr_3 = LegacyDeriver.getBtcAddressTaprootNoScriptFromEth(
+            x1_3,
+            y1_3,
+            x2_3,
+            y2_3,
+            bytes("bcrt"),
+            ethAddr_3
+        );
+        assertEq(expectedBtcAddr_3, btcAddr_3);
+    }
+}


### PR DESCRIPTION
- The new generation of BTC addresses using hmac remained in BTCDepositAddressDeriver
- The old taproot address generation was moved to LegacyBTCDepositAddressDeriver.
- The tests have also changed accordingly. The old tests have been moved to Legacy.
- Added Ownable to BTCDepositAddressDeriver because it will be an independent contract.